### PR TITLE
Sync Mac Claude settings with remote bootstrap

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -113,7 +113,10 @@ cat > "$HOME/.claude/settings.json" <<'SETTINGS'
     "context7@claude-plugins-official": true,
     "github@claude-plugins-official": true
   },
-  "skipDangerousModePermissionPrompt": true
+  "skipDangerousModePermissionPrompt": true,
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
 }
 SETTINGS
 echo "  OK    ~/.claude/settings.json"


### PR DESCRIPTION
Add missing `env` block to `scripts/bootstrap.sh` to match `remote/bootstrap.sh`.

Fixes #2 in issue #9: Claude settings differ between Mac and bootstrap heredoc.

Generated with [Claude Code](https://claude.ai/code)